### PR TITLE
Fix cellulose extraction from wood naming

### DIFF
--- a/Vile's Materials Science/Common/Defs/RecipesDefs/Recipes_Chemical.xml
+++ b/Vile's Materials Science/Common/Defs/RecipesDefs/Recipes_Chemical.xml
@@ -130,7 +130,7 @@
 	</RecipeDef>
 	<RecipeDef>
 		<defName>MakeCelluloseWood</defName>
-		<label>Extract cellulose from cotton or hemp (x15)</label>
+		<label>Extract cellulose from wood (x15)</label>
 		<description>Extract cellulose for making ammo propellant or rayon fabric. Slow and inefficient.</description>
 		<jobString>Extracting cellulose.</jobString>
 		<workAmount>1200</workAmount>


### PR DESCRIPTION
The description of the recipe is wrong as you are using not cotton or hemp for it, but wood.